### PR TITLE
Add Pandora service support

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
             <option value="2BA92214">BBC iPlayer</option>
             <option value="5E645BCC">BubbleUPnP</option>
             <option value="12F05308">TuneIn Free</option>
+            <option value="211CD751">Pandora</option>
             <option value="0F5096E8">Chrome Mirroring</option>
             <option value="85CDB22F">Chrome Audio Mirroring</option>
             <option value="CC1AD845">Default Media Receiver</option>


### PR DESCRIPTION
Great little utility! I noticed that Pandora was not listed as an option. As per [this post](https://forum.universal-devices.com/topic/24341-chromecast-polyglot-nodeserver/?do=findComment&comment=257177), the AppID should be 211CD751. It seems to work in my own tests using that AppID.